### PR TITLE
Support MOK blacklist

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -513,8 +513,8 @@ static void show_efi_hash (EFI_GUID Type, void *Mok, UINTN MokSize)
 	UINTN hash_num;
 	UINT8 *hash;
 	CHAR16 **menu_strings;
-	int key_num = 0;
-	int i;
+	UINTN key_num = 0;
+	UINTN i;
 
 	sig_size = sha_size(Type) + sizeof(EFI_GUID);
 	if ((MokSize % sig_size) != 0) {
@@ -592,7 +592,7 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 {
 	INTN MokNum = 0;
 	MokListNode *keys = NULL;
-	int key_num = 0;
+	UINT32 key_num = 0;
 	CHAR16 **menu_strings;
 	int i;
 
@@ -1118,7 +1118,7 @@ static int match_hash (UINT8 *hash, UINT32 hash_size, int start,
 		       void *hash_list, UINT32 list_num)
 {
 	UINT8 *ptr;
-	int i;
+	UINTN i;
 
 	ptr = hash_list + sizeof(EFI_GUID);
 	for (i = start; i < list_num; i++) {
@@ -1133,7 +1133,7 @@ static int match_hash (UINT8 *hash, UINT32 hash_size, int start,
 static void mem_move (void *dest, void *src, UINTN size)
 {
 	UINT8 *d, *s;
-	int i;
+	UINTN i;
 
 	d = (UINT8 *)dest;
 	s = (UINT8 *)src;
@@ -1190,7 +1190,7 @@ static void delete_hash_list (EFI_GUID Type, void *hash_list, UINT32 list_size,
 	UINT32 hash_num;
 	UINT32 sig_size;
 	UINT8 *hash;
-	int i;
+	UINT32 i;
 
 	hash_size = sha_size (Type);
 	sig_size = hash_size + sizeof(EFI_GUID);

--- a/MokManager.c
+++ b/MokManager.c
@@ -25,6 +25,9 @@
 #define EFI_VARIABLE_APPEND_WRITE 0x00000040
 
 EFI_GUID SHIM_LOCK_GUID = { 0x605dab50, 0xe046, 0x4300, {0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23} };
+EFI_GUID EFI_CERT_SHA224_GUID = { 0xb6e5233, 0xa65c, 0x44c9, {0x94, 0x7, 0xd9, 0xab, 0x83, 0xbf, 0xc8, 0xbd} };
+EFI_GUID EFI_CERT_SHA384_GUID = { 0xff3e5307, 0x9fd0, 0x48c9, {0x85, 0xf1, 0x8a, 0xd5, 0x6c, 0x70, 0x1e, 0x1} };
+EFI_GUID EFI_CERT_SHA512_GUID = { 0x93e0fae, 0xa6c4, 0x4f50, {0x9f, 0x1b, 0xd4, 0x1e, 0x2b, 0x89, 0xc1, 0x9a} };
 
 #define CERT_STRING L"Select an X509 certificate to enroll:\n\n"
 #define HASH_STRING L"Select a file to trust:\n\n"
@@ -96,11 +99,20 @@ done:
 static BOOLEAN is_sha_hash (EFI_GUID Type)
 {
 	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha224 = EFI_CERT_SHA224_GUID;
 	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
+	EFI_GUID Sha384 = EFI_CERT_SHA384_GUID;
+	EFI_GUID Sha512 = EFI_CERT_SHA512_GUID;
 
 	if (CompareGuid(&Type, &Sha1) == 0)
 		return TRUE;
+	else if (CompareGuid(&Type, &Sha224) == 0)
+		return TRUE;
 	else if (CompareGuid(&Type, &Sha256) == 0)
+		return TRUE;
+	else if (CompareGuid(&Type, &Sha384) == 0)
+		return TRUE;
+	else if (CompareGuid(&Type, &Sha512) == 0)
 		return TRUE;
 
 	return FALSE;
@@ -109,12 +121,21 @@ static BOOLEAN is_sha_hash (EFI_GUID Type)
 static UINT32 sha_size (EFI_GUID Type)
 {
 	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha224 = EFI_CERT_SHA224_GUID;
 	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
+	EFI_GUID Sha384 = EFI_CERT_SHA384_GUID;
+	EFI_GUID Sha512 = EFI_CERT_SHA512_GUID;
 
 	if (CompareGuid(&Type, &Sha1) == 0)
 		return SHA1_DIGEST_SIZE;
+	else if (CompareGuid(&Type, &Sha224) == 0)
+		return SHA224_DIGEST_LENGTH;
 	else if (CompareGuid(&Type, &Sha256) == 0)
 		return SHA256_DIGEST_SIZE;
+	else if (CompareGuid(&Type, &Sha384) == 0)
+		return SHA384_DIGEST_LENGTH;
+	else if (CompareGuid(&Type, &Sha512) == 0)
+		return SHA512_DIGEST_LENGTH;
 
 	return 0;
 }
@@ -439,7 +460,10 @@ static void show_x509_info (X509 *X509Cert, UINT8 *hash)
 static void show_sha_digest (EFI_GUID Type, UINT8 *hash)
 {
 	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha224 = EFI_CERT_SHA224_GUID;
 	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
+	EFI_GUID Sha384 = EFI_CERT_SHA384_GUID;
+	EFI_GUID Sha512 = EFI_CERT_SHA512_GUID;
 	CHAR16 *text[5];
 	POOL_PRINT hash_string1;
 	POOL_PRINT hash_string2;
@@ -449,9 +473,18 @@ static void show_sha_digest (EFI_GUID Type, UINT8 *hash)
 	if (CompareGuid(&Type, &Sha1) == 0) {
 		length = SHA1_DIGEST_SIZE;
 		text[0] = L"SHA1 hash";
+	} else if (CompareGuid(&Type, &Sha224) == 0) {
+		length = SHA224_DIGEST_LENGTH;
+		text[0] = L"SHA224 hash";
 	} else if (CompareGuid(&Type, &Sha256) == 0) {
 		length = SHA256_DIGEST_SIZE;
 		text[0] = L"SHA256 hash";
+	} else if (CompareGuid(&Type, &Sha384) == 0) {
+		length = SHA384_DIGEST_LENGTH;
+		text[0] = L"SHA384 hash";
+	} else if (CompareGuid(&Type, &Sha512) == 0) {
+		length = SHA512_DIGEST_LENGTH;
+		text[0] = L"SHA512 hash";
 	} else {
 		return;
 	}
@@ -1113,7 +1146,7 @@ static void mem_move (void *dest, void *src, UINTN size)
 		d[i] = s[i];
 }
 
-static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
+static void delete_hash_in_list (EFI_GUID Type, UINT8 *hash, UINT32 hash_size,
 				 MokListNode *mok, INTN mok_num)
 {
 	UINT32 sig_size;
@@ -1125,7 +1158,8 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 	sig_size = hash_size + sizeof(EFI_GUID);
 
 	for (i = 0; i < mok_num; i++) {
-		if (!is_sha_hash(mok[i].Type) || (mok[i].MokSize < sig_size))
+		if ((CompareGuid(&(mok[i].Type), &Type) != 0) ||
+		    (mok[i].MokSize < sig_size))
 			continue;
 
 		list_num = mok[i].MokSize / sig_size;
@@ -1173,7 +1207,7 @@ static void delete_hash_list (EFI_GUID Type, void *hash_list, UINT32 list_size,
 	hash = hash_list + sizeof(EFI_GUID);
 
 	for (i = 0; i < hash_num; i++) {
-		delete_hash_in_list (hash, hash_size, mok, mok_num);
+		delete_hash_in_list (Type, hash, hash_size, mok, mok_num);
 		hash += sig_size;
 	}
 }

--- a/MokManager.c
+++ b/MokManager.c
@@ -182,10 +182,8 @@ static UINT32 count_keys(void *Data, UINTN DataSize)
 		}
 
 		if (!is_valid_siglist(CertList->SignatureType, CertList->SignatureSize)) {
-			dbsize -= CertList->SignatureListSize;
-			CertList = (EFI_SIGNATURE_LIST *) ((UINT8 *) CertList +
-						  CertList->SignatureListSize);
-			continue;
+			console_errorbox(L"Invalid signature list found");
+			return 0;
 		}
 
 		MokNum++;
@@ -219,12 +217,9 @@ static MokListNode *build_mok_list(UINT32 num, void *Data, UINTN DataSize) {
 			FreePool(list);
 			return NULL;
 		}
-		if (!is_valid_siglist(CertList->SignatureType, CertList->SignatureSize)) {
-			dbsize -= CertList->SignatureListSize;
-			CertList = (EFI_SIGNATURE_LIST *)((UINT8 *) CertList +
-						  CertList->SignatureListSize);
-			continue;
-		}
+
+		/* Omit the signature check here since we already did it
+		   in count_keys() */
 
 		Cert = (EFI_SIGNATURE_DATA *) (((UINT8 *) CertList) +
 		  sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);

--- a/MokManager.c
+++ b/MokManager.c
@@ -565,7 +565,7 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 	if (KeyListSize < (sizeof(EFI_SIGNATURE_LIST) +
 			   sizeof(EFI_SIGNATURE_DATA))) {
 		console_notify(L"No MOK keys found");
-		return 0;
+		return EFI_NOT_FOUND;
 	}
 
 	MokNum = count_keys(KeyList, KeyListSize);
@@ -575,7 +575,7 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 
 	if (!keys) {
 		console_notify(L"Failed to construct key list");
-		return 0;
+		return EFI_ABORTED;
 	}
 
 	menu_strings = AllocateZeroPool(sizeof(CHAR16 *) * (MokNum + 2));
@@ -900,7 +900,7 @@ static EFI_STATUS store_keys (void *MokNew, UINTN MokNewSize, int authenticate,
 	return EFI_SUCCESS;
 }
 
-static UINTN mok_enrollment_prompt (void *MokNew, UINTN MokNewSize, int auth,
+static INTN mok_enrollment_prompt (void *MokNew, UINTN MokNewSize, int auth,
 				    BOOLEAN MokX)
 {
 	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;

--- a/MokManager.c
+++ b/MokManager.c
@@ -93,11 +93,53 @@ done:
 	return status;
 }
 
+static BOOLEAN is_sha_hash (EFI_GUID Type)
+{
+	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
+
+	if (CompareGuid(&Type, &Sha1) == 0)
+		return TRUE;
+	else if (CompareGuid(&Type, &Sha256) == 0)
+		return TRUE;
+
+	return FALSE;
+}
+
+static UINT32 sha_size (EFI_GUID Type)
+{
+	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
+
+	if (CompareGuid(&Type, &Sha1) == 0)
+		return SHA1_DIGEST_SIZE;
+	else if (CompareGuid(&Type, &Sha256) == 0)
+		return SHA256_DIGEST_SIZE;
+
+	return 0;
+}
+
+static BOOLEAN is_valid_siglist (EFI_GUID Type, UINT32 SigSize)
+{
+	EFI_GUID CertType = X509_GUID;
+	UINT32 hash_sig_size;
+
+	if (CompareGuid (&Type, &CertType) == 0 && SigSize != 0)
+		return TRUE;
+
+	if (!is_sha_hash (Type))
+		return FALSE;
+
+	hash_sig_size = sha_size (Type) + sizeof(EFI_GUID);
+	if (SigSize != hash_sig_size)
+		return FALSE;
+
+	return TRUE;
+}
+
 static UINT32 count_keys(void *Data, UINTN DataSize)
 {
 	EFI_SIGNATURE_LIST *CertList = Data;
-	EFI_GUID CertType = X509_GUID;
-	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	UINTN dbsize = DataSize;
 	UINT32 MokNum = 0;
 	void *end = Data + DataSize;
@@ -112,18 +154,7 @@ static UINT32 count_keys(void *Data, UINTN DataSize)
 			return 0;
 		}
 
-		if ((CompareGuid (&CertList->SignatureType, &CertType) != 0) &&
-		    (CompareGuid (&CertList->SignatureType, &HashType) != 0)) {
-			console_notify(L"Doesn't look like a key or hash");
-			dbsize -= CertList->SignatureListSize;
-			CertList = (EFI_SIGNATURE_LIST *) ((UINT8 *) CertList +
-						  CertList->SignatureListSize);
-			continue;
-		}
-
-		if ((CompareGuid (&CertList->SignatureType, &CertType) != 0) &&
-		    (CertList->SignatureSize != 48)) {
-			console_notify(L"Doesn't look like a valid hash");
+		if (!is_valid_siglist(CertList->SignatureType, CertList->SignatureSize)) {
 			dbsize -= CertList->SignatureListSize;
 			CertList = (EFI_SIGNATURE_LIST *) ((UINT8 *) CertList +
 						  CertList->SignatureListSize);
@@ -144,7 +175,6 @@ static MokListNode *build_mok_list(UINT32 num, void *Data, UINTN DataSize) {
 	EFI_SIGNATURE_LIST *CertList = Data;
 	EFI_SIGNATURE_DATA *Cert;
 	EFI_GUID CertType = X509_GUID;
-	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	UINTN dbsize = DataSize;
 	UINTN count = 0;
 	void *end = Data + DataSize;
@@ -162,16 +192,7 @@ static MokListNode *build_mok_list(UINT32 num, void *Data, UINTN DataSize) {
 			FreePool(list);
 			return NULL;
 		}
-		if ((CompareGuid (&CertList->SignatureType, &CertType) != 0) &&
-		    (CompareGuid (&CertList->SignatureType, &HashType) != 0)) {
-			dbsize -= CertList->SignatureListSize;
-			CertList = (EFI_SIGNATURE_LIST *)((UINT8 *) CertList +
-						  CertList->SignatureListSize);
-			continue;
-		}
-
-		if ((CompareGuid (&CertList->SignatureType, &HashType) == 0) &&
-		    (CertList->SignatureSize != 48)) {
+		if (!is_valid_siglist(CertList->SignatureType, CertList->SignatureSize)) {
 			dbsize -= CertList->SignatureListSize;
 			CertList = (EFI_SIGNATURE_LIST *)((UINT8 *) CertList +
 						  CertList->SignatureListSize);
@@ -409,22 +430,34 @@ static void show_x509_info (X509 *X509Cert, UINT8 *hash)
 	FreePool(text);
 }
 
-static void show_sha256_digest (UINT8 *hash)
+static void show_sha_digest (EFI_GUID Type, UINT8 *hash)
 {
+	EFI_GUID Sha1 = EFI_CERT_SHA1_GUID;
+	EFI_GUID Sha256 = EFI_CERT_SHA256_GUID;
 	CHAR16 *text[5];
 	POOL_PRINT hash_string1;
 	POOL_PRINT hash_string2;
 	int i;
+	int length;
+
+	if (CompareGuid(&Type, &Sha1) == 0) {
+		length = SHA1_DIGEST_SIZE;
+		text[0] = L"SHA1 hash";
+	} else if (CompareGuid(&Type, &Sha256) == 0) {
+		length = SHA256_DIGEST_SIZE;
+		text[0] = L"SHA256 hash";
+	} else {
+		return;
+	}
 
 	ZeroMem(&hash_string1, sizeof(hash_string1));
 	ZeroMem(&hash_string2, sizeof(hash_string2));
 
-	text[0] = L"SHA256 hash";
 	text[1] = L"";
 
-	for (i=0; i<16; i++)
+	for (i=0; i<length/2; i++)
 		CatPrint(&hash_string1, L"%02x ", hash[i]);
-	for (i=16; i<32; i++)
+	for (i=length/2; i<length; i++)
 		CatPrint(&hash_string2, L"%02x ", hash[i]);
 
 	text[2] = hash_string1.str;
@@ -440,7 +473,7 @@ static void show_sha256_digest (UINT8 *hash)
 		FreePool(hash_string2.str);
 }
 
-static void show_efi_hash (void *Mok, UINTN MokSize)
+static void show_efi_hash (EFI_GUID Type, void *Mok, UINTN MokSize)
 {
 	UINTN sig_size;
 	UINTN hash_num;
@@ -449,7 +482,7 @@ static void show_efi_hash (void *Mok, UINTN MokSize)
 	int key_num = 0;
 	int i;
 
-	sig_size = SHA256_DIGEST_SIZE + sizeof(EFI_GUID);
+	sig_size = sha_size(Type) + sizeof(EFI_GUID);
 	if ((MokSize % sig_size) != 0) {
 		console_errorbox(L"Corrupted Hash List");
 		return;
@@ -458,7 +491,7 @@ static void show_efi_hash (void *Mok, UINTN MokSize)
 
 	if (hash_num == 1) {
 		hash = (UINT8 *)Mok + sizeof(EFI_GUID);
-		show_sha256_digest(hash);
+		show_sha_digest(Type, hash);
 		return;
 	}
 
@@ -481,7 +514,7 @@ static void show_efi_hash (void *Mok, UINTN MokSize)
 			break;
 
 		hash = (UINT8 *)Mok + sig_size*key_num + sizeof(EFI_GUID);
-		show_sha256_digest(hash);
+		show_sha_digest(Type, hash);
 	}
 
 	for (i=0; menu_strings[i] != NULL; i++)
@@ -496,7 +529,6 @@ static void show_mok_info (EFI_GUID Type, void *Mok, UINTN MokSize)
 	UINT8 hash[SHA1_DIGEST_SIZE];
 	X509 *X509Cert;
 	EFI_GUID CertType = X509_GUID;
-	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 
 	if (!Mok || MokSize == 0)
 		return;
@@ -517,8 +549,8 @@ static void show_mok_info (EFI_GUID Type, void *Mok, UINTN MokSize)
 			console_notify(L"Not a valid X509 certificate");
 			return;
 		}
-	} else if (CompareGuid (&Type, &HashType) == 0) {
-		show_efi_hash(Mok, MokSize);
+	} else if (is_sha_hash(Type)) {
+		show_efi_hash(Type, Mok, MokSize);
 	}
 }
 
@@ -1005,7 +1037,7 @@ static EFI_STATUS write_back_mok_list (MokListNode *list, INTN key_num,
 		} else {
 			CertList->SignatureListSize = list[i].MokSize +
 						      sizeof(EFI_SIGNATURE_LIST);
-			CertList->SignatureSize = SHA256_DIGEST_SIZE + sizeof(EFI_GUID);
+			CertList->SignatureSize = sha_size(list[i].Type) + sizeof(EFI_GUID);
 
 			CopyMem(CertData, list[i].Mok, list[i].MokSize);
 		}
@@ -1077,7 +1109,6 @@ static void mem_move (void *dest, void *src, UINTN size)
 static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 				 MokListNode *mok, INTN mok_num)
 {
-	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	UINT32 sig_size;
 	UINT32 list_num;
 	int i, del_ind;
@@ -1087,8 +1118,7 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 	sig_size = hash_size + sizeof(EFI_GUID);
 
 	for (i = 0; i < mok_num; i++) {
-		if ((CompareGuid(&(mok[i].Type), &HashType) != 0) ||
-		    (mok[i].MokSize < sig_size))
+		if (!is_sha_hash(mok[i].Type) || (mok[i].MokSize < sig_size))
 			continue;
 
 		list_num = mok[i].MokSize / sig_size;
@@ -1117,7 +1147,7 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 	}
 }
 
-static void delete_hash_list (void *hash_list, UINT32 list_size,
+static void delete_hash_list (EFI_GUID Type, void *hash_list, UINT32 list_size,
 			      MokListNode *mok, INTN mok_num)
 {
 	UINT32 hash_size;
@@ -1126,7 +1156,7 @@ static void delete_hash_list (void *hash_list, UINT32 list_size,
 	UINT8 *hash;
 	int i;
 
-	hash_size = SHA256_DIGEST_SIZE;
+	hash_size = sha_size (Type);
 	sig_size = hash_size + sizeof(EFI_GUID);
 	if (list_size < sig_size)
 		return;
@@ -1145,7 +1175,6 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 {
 	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;
 	EFI_GUID CertType = X509_GUID;
-	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	EFI_STATUS efi_status;
 	CHAR16 *db_name;
 	CHAR16 *auth_name;
@@ -1220,9 +1249,9 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 		if (CompareGuid(&(del_key[i].Type), &CertType) == 0) {
 			delete_cert(del_key[i].Mok, del_key[i].MokSize,
 				    mok, mok_num);
-		} else if (CompareGuid(&(del_key[i].Type), &HashType) == 0) {
-			delete_hash_list(del_key[i].Mok, del_key[i].MokSize,
-					 mok, mok_num);
+		} else if (is_sha_hash(del_key[i].Type)) {
+			delete_hash_list(del_key[i].Type, del_key[i].Mok,
+					 del_key[i].MokSize, mok, mok_num);
 		}
 	}
 

--- a/MokManager.c
+++ b/MokManager.c
@@ -971,7 +971,9 @@ static EFI_STATUS write_back_mok_list (MokListNode *list, INTN key_num,
 		if (list[i].Mok == NULL)
 			continue;
 
-		DataSize += sizeof(EFI_SIGNATURE_LIST) + sizeof(EFI_GUID);
+		DataSize += sizeof(EFI_SIGNATURE_LIST);
+		if (CompareGuid(&(list[i].Type), &CertType) == 0)
+			DataSize += sizeof(EFI_GUID);
 		DataSize += list[i].MokSize;
 	}
 

--- a/MokManager.c
+++ b/MokManager.c
@@ -470,12 +470,12 @@ static void show_efi_hash (void *Mok, UINTN MokSize)
 	for (i=0; i<hash_num; i++) {
 		menu_strings[i] = PoolPrint(L"View hash %d", i);
 	}
-	menu_strings[i] = StrDuplicate(L"Continue");
+	menu_strings[i] = StrDuplicate(L"Back");
 	menu_strings[i+1] = NULL;
 
 	while (key_num < hash_num) {
 		key_num = console_select((CHAR16 *[]){ L"[Hash List]", NULL },
-					 menu_strings, 0);
+					 menu_strings, key_num);
 
 		if (key_num < 0 || key_num >= hash_num)
 			break;
@@ -560,7 +560,7 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 
 	while (key_num < MokNum) {
 		key_num = console_select((CHAR16 *[]){ title, NULL },
-					 menu_strings, 0);
+					 menu_strings, key_num);
 
 		if (key_num < 0 || key_num >= MokNum)
 			break;
@@ -953,6 +953,7 @@ static EFI_STATUS write_back_mok_list (MokListNode *list, INTN key_num,
 				       BOOLEAN MokX)
 {
 	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;
+	EFI_GUID CertType = X509_GUID;
 	EFI_STATUS efi_status;
 	EFI_SIGNATURE_LIST *CertList;
 	EFI_SIGNATURE_DATA *CertData;
@@ -989,17 +990,24 @@ static EFI_STATUS write_back_mok_list (MokListNode *list, INTN key_num,
 			   sizeof(EFI_SIGNATURE_LIST));
 
 		CertList->SignatureType = list[i].Type;
-		CertList->SignatureListSize = list[i].MokSize +
-					      sizeof(EFI_SIGNATURE_LIST) +
-					      sizeof(EFI_SIGNATURE_DATA) - 1;
 		CertList->SignatureHeaderSize = 0;
-		CertList->SignatureSize = list[i].MokSize + sizeof(EFI_GUID);
 
-		CertData->SignatureOwner = shim_lock_guid;
-		CopyMem(CertData->SignatureData, list[i].Mok, list[i].MokSize);
+		if (CompareGuid(&(list[i].Type), &CertType) == 0) {
+			CertList->SignatureListSize = list[i].MokSize +
+						      sizeof(EFI_SIGNATURE_LIST) +
+						      sizeof(EFI_GUID);
+			CertList->SignatureSize = list[i].MokSize + sizeof(EFI_GUID);
 
-		ptr = (uint8_t *)ptr + sizeof(EFI_SIGNATURE_LIST) +
-		      sizeof(EFI_GUID) + list[i].MokSize;
+			CertData->SignatureOwner = shim_lock_guid;
+			CopyMem(CertData->SignatureData, list[i].Mok, list[i].MokSize);
+		} else {
+			CertList->SignatureListSize = list[i].MokSize +
+						      sizeof(EFI_SIGNATURE_LIST);
+			CertList->SignatureSize = SHA256_DIGEST_SIZE + sizeof(EFI_GUID);
+
+			CopyMem(CertData, list[i].Mok, list[i].MokSize);
+		}
+		ptr = (uint8_t *)ptr + CertList->SignatureListSize;
 	}
 
 	efi_status = uefi_call_wrapper(RT->SetVariable, 5, db_name,

--- a/MokManager.c
+++ b/MokManager.c
@@ -154,6 +154,12 @@ static UINT32 count_keys(void *Data, UINTN DataSize)
 			return 0;
 		}
 
+		if (CertList->SignatureListSize == 0 ||
+		    CertList->SignatureListSize <= CertList->SignatureSize) {
+			console_errorbox(L"Corrupted signature list");
+			return 0;
+		}
+
 		if (!is_valid_siglist(CertList->SignatureType, CertList->SignatureSize)) {
 			dbsize -= CertList->SignatureListSize;
 			CertList = (EFI_SIGNATURE_LIST *) ((UINT8 *) CertList +
@@ -569,12 +575,13 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 	}
 
 	MokNum = count_keys(KeyList, KeyListSize);
-	if (MokNum == 0)
-		return 0;
+	if (MokNum == 0) {
+		console_errorbox(L"Invalid key list");
+		return EFI_ABORTED;
+	}
 	keys = build_mok_list(MokNum, KeyList, KeyListSize);
-
 	if (!keys) {
-		console_notify(L"Failed to construct key list");
+		console_errorbox(L"Failed to construct key list");
 		return EFI_ABORTED;
 	}
 
@@ -1221,7 +1228,13 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 
 	efi_status = get_variable_attr (db_name, &MokListData, &MokListDataSize,
 				        shim_lock_guid, &attributes);
-	if (attributes & EFI_VARIABLE_RUNTIME_ACCESS) {
+	if (efi_status != EFI_SUCCESS) {
+		if (MokX)
+			console_errorbox(L"Failed to retrieve MokListX");
+		else
+			console_errorbox(L"Failed to retrieve MokList");
+		return EFI_ABORTED;
+	} else if (attributes & EFI_VARIABLE_RUNTIME_ACCESS) {
 		if (MokX) {
 			err_str1 = L"MokListX is compromised!";
 			err_str2 = L"Erase all keys in MokListX!";
@@ -1230,7 +1243,11 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 			err_str2 = L"Erase all keys in MokList!";
 		}
 		console_alertbox((CHAR16 *[]){err_str1, err_str2, NULL});
-		LibDeleteVariable(db_name, &shim_lock_guid);
+		uefi_call_wrapper(RT->SetVariable, 5, db_name,
+				  &shim_lock_guid,
+				  EFI_VARIABLE_NON_VOLATILE |
+				  EFI_VARIABLE_BOOTSERVICE_ACCESS,
+				  0, NULL);
 		return EFI_ACCESS_DENIED;
 	}
 
@@ -1240,9 +1257,41 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 
 	/* Construct lists */
 	mok_num = count_keys(MokListData, MokListDataSize);
+	if (mok_num == 0) {
+		if (MokX) {
+			err_str1 = L"Failed to construct the key list of MokListX";
+			err_str2 = L"Reset MokListX!";
+		} else {
+			err_str1 = L"Failed to construct the key list of MokList";
+			err_str2 = L"Reset MokList!";
+		}
+		console_alertbox((CHAR16 *[]){err_str1, err_str2, NULL});
+		uefi_call_wrapper(RT->SetVariable, 5, db_name,
+				  &shim_lock_guid,
+				  EFI_VARIABLE_NON_VOLATILE |
+				  EFI_VARIABLE_BOOTSERVICE_ACCESS,
+				  0, NULL);
+		efi_status = EFI_ABORTED;
+		goto error;
+	}
 	mok = build_mok_list(mok_num, MokListData, MokListDataSize);
+	if (!mok) {
+		console_errorbox(L"Failed to construct key list");
+		efi_status = EFI_ABORTED;
+		goto error;
+	}
 	del_num = count_keys(MokDel, MokDelSize);
+	if (del_num == 0) {
+		console_errorbox(L"Invalid key delete list");
+		efi_status = EFI_ABORTED;
+		goto error;
+	}
 	del_key = build_mok_list(del_num, MokDel, MokDelSize);
+	if (!del_key) {
+		console_errorbox(L"Failed to construct key list");
+		efi_status = EFI_ABORTED;
+		goto error;
+	}
 
 	/* Search and destroy */
 	for (i = 0; i < del_num; i++) {
@@ -1257,6 +1306,7 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 
 	efi_status = write_back_mok_list(mok, mok_num, MokX);
 
+error:
 	if (MokListData)
 		FreePool(MokListData);
 	if (mok)

--- a/MokManager.c
+++ b/MokManager.c
@@ -1018,9 +1018,116 @@ static EFI_STATUS write_back_mok_list (MokListNode *list, INTN key_num,
 	return EFI_SUCCESS;
 }
 
+static void delete_cert (void *key, UINT32 key_size,
+			 MokListNode *mok, INTN mok_num)
+{
+	EFI_GUID CertType = X509_GUID;
+	int i;
+
+	for (i = 0; i < mok_num; i++) {
+		if (CompareGuid(&(mok[i].Type), &CertType) != 0)
+			continue;
+
+		if (mok[i].MokSize == key_size &&
+		    CompareMem(key, mok[i].Mok, key_size) == 0) {
+			/* Remove the key */
+			mok[i].Mok = NULL;
+			mok[i].MokSize = 0;
+		}
+	}
+}
+
+static int match_hash (UINT8 *hash, UINT32 hash_size,
+		       void *hash_list, UINT32 list_num)
+{
+	UINT8 *ptr;
+	int i;
+
+	ptr = hash_list + sizeof(EFI_GUID);
+	for (i = 0; i < list_num; i++) {
+		if (CompareMem(hash, ptr, hash_size) == 0)
+			return i;
+		ptr += hash_size + sizeof(EFI_GUID);
+	}
+
+	return -1;
+}
+
+static void mem_move (void *dest, void *src, UINTN size)
+{
+	UINT8 *d, *s;
+	int i;
+
+	d = (UINT8 *)dest;
+	s = (UINT8 *)src;
+	for (i = 0; i < size; i++)
+		d[i] = s[i];
+}
+
+static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
+				 MokListNode *mok, INTN mok_num)
+{
+	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
+	UINT32 sig_size;
+	int i, del_ind;
+	void *start, *end;
+	UINT32 remain;
+
+	sig_size = hash_size + sizeof(EFI_GUID);
+
+	for (i = 0; i < mok_num; i++) {
+		if ((CompareGuid(&(mok[i].Type), &HashType) != 0) ||
+		    (mok[i].MokSize < sig_size))
+			continue;
+
+		del_ind = match_hash(hash, hash_size, mok[i].Mok,
+				     mok[i].MokSize);
+		if (del_ind < 0)
+			continue;
+		/* Remove the hash */
+		if (sig_size == mok[i].MokSize) {
+			mok[i].Mok = NULL;
+			mok[i].MokSize = 0;
+		} else {
+			start = mok[i].Mok + del_ind * sig_size;
+			end = start + sig_size;
+			remain = mok[i].MokSize - (del_ind + 1)*sig_size;
+
+			mem_move(start, end, remain);
+			mok[i].MokSize -= sig_size;
+		}
+	}
+}
+
+static void delete_hash_list (void *hash_list, UINT32 list_size,
+			      MokListNode *mok, INTN mok_num)
+{
+	UINT32 hash_size;
+	UINT32 hash_num;
+	UINT32 sig_size;
+	UINT8 *hash;
+	int i;
+
+	hash_size = SHA256_DIGEST_SIZE;
+	sig_size = hash_size + sizeof(EFI_GUID);
+	if (list_size < sig_size)
+		return;
+
+	hash_num = list_size / sig_size;
+
+	hash = hash_list + sizeof(EFI_GUID);
+
+	for (i = 0; i < hash_num; i++) {
+		delete_hash_in_list (hash, hash_size, mok, mok_num);
+		hash += sig_size;
+	}
+}
+
 static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 {
 	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;
+	EFI_GUID CertType = X509_GUID;
+	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	EFI_STATUS efi_status;
 	CHAR16 *db_name;
 	CHAR16 *auth_name;
@@ -1033,7 +1140,7 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 	UINTN MokListDataSize = 0;
 	MokListNode *mok, *del_key;
 	INTN mok_num, del_num;
-	int i, j;
+	int i;
 
 	if (MokX) {
 		db_name = L"MokListX";
@@ -1092,15 +1199,12 @@ static EFI_STATUS delete_keys (void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 
 	/* Search and destroy */
 	for (i = 0; i < del_num; i++) {
-		UINT32 key_size = del_key[i].MokSize;
-		void *key = del_key[i].Mok;
-		for (j = 0; j < mok_num; j++) {
-			if (mok[j].MokSize == key_size &&
-			    CompareMem(key, mok[j].Mok, key_size) == 0) {
-				/* Remove the key */
-				mok[j].Mok = NULL;
-				mok[j].MokSize = 0;
-			}
+		if (CompareGuid(&(del_key[i].Type), &CertType) == 0) {
+			delete_cert(del_key[i].Mok, del_key[i].MokSize,
+				    mok, mok_num);
+		} else if (CompareGuid(&(del_key[i].Type), &HashType) == 0) {
+			delete_hash_list(del_key[i].Mok, del_key[i].MokSize,
+					 mok, mok_num);
 		}
 	}
 

--- a/MokManager.c
+++ b/MokManager.c
@@ -1079,6 +1079,7 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 {
 	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 	UINT32 sig_size;
+	UINT32 list_num;
 	int i, del_ind;
 	void *start, *end;
 	UINT32 remain;
@@ -1090,8 +1091,10 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 		    (mok[i].MokSize < sig_size))
 			continue;
 
+		list_num = mok[i].MokSize / sig_size;
+
 		del_ind = match_hash(hash, hash_size, 0, mok[i].Mok,
-				     mok[i].MokSize);
+				     list_num);
 		while (del_ind >= 0) {
 			/* Remove the hash */
 			if (sig_size == mok[i].MokSize) {
@@ -1106,9 +1109,10 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 
 			mem_move(start, end, remain);
 			mok[i].MokSize -= sig_size;
+			list_num--;
 
 			del_ind = match_hash(hash, hash_size, del_ind,
-					     mok[i].Mok, mok[i].MokSize);
+					     mok[i].Mok, list_num);
 		}
 	}
 }

--- a/MokManager.c
+++ b/MokManager.c
@@ -1037,14 +1037,14 @@ static void delete_cert (void *key, UINT32 key_size,
 	}
 }
 
-static int match_hash (UINT8 *hash, UINT32 hash_size,
+static int match_hash (UINT8 *hash, UINT32 hash_size, int start,
 		       void *hash_list, UINT32 list_num)
 {
 	UINT8 *ptr;
 	int i;
 
 	ptr = hash_list + sizeof(EFI_GUID);
-	for (i = 0; i < list_num; i++) {
+	for (i = start; i < list_num; i++) {
 		if (CompareMem(hash, ptr, hash_size) == 0)
 			return i;
 		ptr += hash_size + sizeof(EFI_GUID);
@@ -1080,21 +1080,25 @@ static void delete_hash_in_list (UINT8 *hash, UINT32 hash_size,
 		    (mok[i].MokSize < sig_size))
 			continue;
 
-		del_ind = match_hash(hash, hash_size, mok[i].Mok,
+		del_ind = match_hash(hash, hash_size, 0, mok[i].Mok,
 				     mok[i].MokSize);
-		if (del_ind < 0)
-			continue;
-		/* Remove the hash */
-		if (sig_size == mok[i].MokSize) {
-			mok[i].Mok = NULL;
-			mok[i].MokSize = 0;
-		} else {
+		while (del_ind >= 0) {
+			/* Remove the hash */
+			if (sig_size == mok[i].MokSize) {
+				mok[i].Mok = NULL;
+				mok[i].MokSize = 0;
+				break;
+			}
+
 			start = mok[i].Mok + del_ind * sig_size;
 			end = start + sig_size;
 			remain = mok[i].MokSize - (del_ind + 1)*sig_size;
 
 			mem_move(start, end, remain);
 			mok[i].MokSize -= sig_size;
+
+			del_ind = match_hash(hash, hash_size, del_ind,
+					     mok[i].Mok, mok[i].MokSize);
 		}
 	}
 }

--- a/MokManager.c
+++ b/MokManager.c
@@ -187,9 +187,16 @@ static MokListNode *build_mok_list(UINT32 num, void *Data, UINTN DataSize) {
 			return NULL;
 		}
 
-		list[count].MokSize = CertList->SignatureSize - sizeof(EFI_GUID);
-		list[count].Mok = (void *)Cert->SignatureData;
 		list[count].Type = CertList->SignatureType;
+		if (CompareGuid (&CertList->SignatureType, &CertType) == 0) {
+			list[count].MokSize = CertList->SignatureSize -
+					      sizeof(EFI_GUID);
+			list[count].Mok = (void *)Cert->SignatureData;
+		} else {
+			list[count].MokSize = CertList->SignatureListSize -
+					      sizeof(EFI_SIGNATURE_LIST);
+			list[count].Mok = (void *)Cert;
+		}
 
 		/* MOK out of bounds? */
 		if (list[count].MokSize > (unsigned long)end -
@@ -402,7 +409,7 @@ static void show_x509_info (X509 *X509Cert, UINT8 *hash)
 	FreePool(text);
 }
 
-static void show_efi_hash (UINT8 *hash)
+static void show_sha256_digest (UINT8 *hash)
 {
 	CHAR16 *text[5];
 	POOL_PRINT hash_string1;
@@ -433,16 +440,68 @@ static void show_efi_hash (UINT8 *hash)
 		FreePool(hash_string2.str);
 }
 
-static void show_mok_info (void *Mok, UINTN MokSize)
+static void show_efi_hash (void *Mok, UINTN MokSize)
+{
+	UINTN sig_size;
+	UINTN hash_num;
+	UINT8 *hash;
+	CHAR16 **menu_strings;
+	int key_num = 0;
+	int i;
+
+	sig_size = SHA256_DIGEST_SIZE + sizeof(EFI_GUID);
+	if ((MokSize % sig_size) != 0) {
+		console_errorbox(L"Corrupted Hash List");
+		return;
+	}
+	hash_num = MokSize / sig_size;
+
+	if (hash_num == 1) {
+		hash = (UINT8 *)Mok + sizeof(EFI_GUID);
+		show_sha256_digest(hash);
+		return;
+	}
+
+	menu_strings = AllocateZeroPool(sizeof(CHAR16 *) * (hash_num + 2));
+	if (!menu_strings) {
+		console_errorbox(L"Out of Resources");
+		return;
+	}
+	for (i=0; i<hash_num; i++) {
+		menu_strings[i] = PoolPrint(L"View hash %d", i);
+	}
+	menu_strings[i] = StrDuplicate(L"Continue");
+	menu_strings[i+1] = NULL;
+
+	while (key_num < hash_num) {
+		key_num = console_select((CHAR16 *[]){ L"[Hash List]", NULL },
+					 menu_strings, 0);
+
+		if (key_num < 0 || key_num >= hash_num)
+			break;
+
+		hash = (UINT8 *)Mok + sig_size*key_num + sizeof(EFI_GUID);
+		show_sha256_digest(hash);
+	}
+
+	for (i=0; menu_strings[i] != NULL; i++)
+		FreePool(menu_strings[i]);
+
+	FreePool(menu_strings);
+}
+
+static void show_mok_info (EFI_GUID Type, void *Mok, UINTN MokSize)
 {
 	EFI_STATUS efi_status;
 	UINT8 hash[SHA1_DIGEST_SIZE];
 	X509 *X509Cert;
+	EFI_GUID CertType = X509_GUID;
+	EFI_GUID HashType = EFI_CERT_SHA256_GUID;
 
 	if (!Mok || MokSize == 0)
 		return;
 
-	if (MokSize != SHA256_DIGEST_SIZE) {
+	if (CompareGuid (&Type, &CertType) == 0) {
 		efi_status = get_sha1sum(Mok, MokSize, hash);
 
 		if (efi_status != EFI_SUCCESS) {
@@ -458,8 +517,8 @@ static void show_mok_info (void *Mok, UINTN MokSize)
 			console_notify(L"Not a valid X509 certificate");
 			return;
 		}
-	} else {
-		show_efi_hash(Mok);
+	} else if (CompareGuid (&Type, &HashType) == 0) {
+		show_efi_hash(Mok, MokSize);
 	}
 }
 
@@ -467,7 +526,7 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 {
 	INTN MokNum = 0;
 	MokListNode *keys = NULL;
-	INTN key_num = 0;
+	int key_num = 0;
 	CHAR16 **menu_strings;
 	int i;
 
@@ -503,10 +562,11 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 		key_num = console_select((CHAR16 *[]){ title, NULL },
 					 menu_strings, 0);
 
-		if (key_num < 0)
+		if (key_num < 0 || key_num >= MokNum)
 			break;
-		else if (key_num < MokNum)
-			show_mok_info(keys[key_num].Mok, keys[key_num].MokSize);
+
+		show_mok_info(keys[key_num].Type, keys[key_num].Mok,
+			      keys[key_num].MokSize);
 	}
 
 	for (i=0; menu_strings[i] != NULL; i++)

--- a/shim.c
+++ b/shim.c
@@ -518,6 +518,7 @@ static EFI_STATUS check_blacklist (WIN_CERTIFICATE_EFI_PKCS *cert,
 				   UINT8 *sha256hash, UINT8 *sha1hash)
 {
 	EFI_GUID secure_var = EFI_IMAGE_SECURITY_DATABASE_GUID;
+	EFI_GUID shim_var = SHIM_LOCK_GUID;
 	EFI_SIGNATURE_LIST *dbx = (EFI_SIGNATURE_LIST *)vendor_dbx;
 
 	if (check_db_hash_in_ram(dbx, vendor_dbx_size, sha256hash,
@@ -541,6 +542,14 @@ static EFI_STATUS check_blacklist (WIN_CERTIFICATE_EFI_PKCS *cert,
 	if (cert && check_db_cert(L"dbx", secure_var, cert, sha256hash) ==
 				DATA_FOUND)
 		return EFI_ACCESS_DENIED;
+	if (check_db_hash(L"MokListX", shim_var, sha256hash, SHA256_DIGEST_SIZE,
+			  EFI_CERT_SHA256_GUID) == DATA_FOUND) {
+		return EFI_ACCESS_DENIED;
+	}
+	if (cert && check_db_cert(L"MokListX", shim_var, cert, sha256hash) ==
+				DATA_FOUND) {
+		return EFI_ACCESS_DENIED;
+	}
 
 	return EFI_SUCCESS;
 }

--- a/shim.c
+++ b/shim.c
@@ -1816,7 +1816,8 @@ EFI_STATUS check_mok_request(EFI_HANDLE image_handle)
 	if (check_var(L"MokNew") || check_var(L"MokSB") ||
 	    check_var(L"MokPW") || check_var(L"MokAuth") ||
 	    check_var(L"MokDel") || check_var(L"MokDB") ||
-	    check_var(L"MokXNew") || check_var(L"MokXDel")) {
+	    check_var(L"MokXNew") || check_var(L"MokXDel") ||
+	    check_var(L"MokXAuth")) {
 		efi_status = start_image(image_handle, MOK_MANAGER);
 
 		if (efi_status != EFI_SUCCESS) {

--- a/shim.c
+++ b/shim.c
@@ -1749,6 +1749,33 @@ EFI_STATUS mirror_mok_list()
 }
 
 /*
+ * Copy the boot-services only MokListX variable to the runtime-accessible
+ * MokListXRT variable. It's not marked NV, so the OS can't modify it.
+ */
+EFI_STATUS mirror_mok_list_x()
+{
+	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;
+	EFI_STATUS efi_status;
+	UINT8 *Data = NULL;
+	UINTN DataSize = 0;
+
+	efi_status = get_variable(L"MokListX", &Data, &DataSize, shim_lock_guid);
+	if (efi_status != EFI_SUCCESS)
+		return efi_status;
+
+	efi_status = uefi_call_wrapper(RT->SetVariable, 5, L"MokListXRT",
+				       &shim_lock_guid,
+				       EFI_VARIABLE_BOOTSERVICE_ACCESS
+				       | EFI_VARIABLE_RUNTIME_ACCESS,
+				       DataSize, Data);
+	if (efi_status != EFI_SUCCESS) {
+		console_error(L"Failed to set MokListRT", efi_status);
+	}
+
+	return efi_status;
+}
+
+/*
  * Check if a variable exists
  */
 static BOOLEAN check_var(CHAR16 *varname)
@@ -2092,6 +2119,8 @@ EFI_STATUS efi_main (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 * use of it
 	 */
 	efi_status = mirror_mok_list();
+
+	efi_status = mirror_mok_list_x();
 
 	/*
 	 * Create the runtime MokIgnoreDB variable so the kernel can make

--- a/shim.c
+++ b/shim.c
@@ -1779,7 +1779,8 @@ EFI_STATUS check_mok_request(EFI_HANDLE image_handle)
 
 	if (check_var(L"MokNew") || check_var(L"MokSB") ||
 	    check_var(L"MokPW") || check_var(L"MokAuth") ||
-	    check_var(L"MokDel") || check_var(L"MokDB")) {
+	    check_var(L"MokDel") || check_var(L"MokDB") ||
+	    check_var(L"MokXNew") || check_var(L"MokXDel")) {
 		efi_status = start_image(image_handle, MOK_MANAGER);
 
 		if (efi_status != EFI_SUCCESS) {


### PR DESCRIPTION
This patch set adds the mokx support to allow the user to import the banned keys and hashes. It also includes the patches to improve the hash list to support multiple hashes in one signature list.

The related changes of mokutil is available in https://github.com/lcp/mokutil/tree/mokx-import