### PR TITLE
Explicitly request sysv-style ELF hash sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifneq ($(origin VENDOR_DBX_FILE), undefined)
 	CFLAGS += -DVENDOR_DBX_FILE=\"$(VENDOR_DBX_FILE)\"
 endif
 
-LDFLAGS		= -nostdlib -znocombreloc -T $(EFI_LDS) -shared -Bsymbolic -L$(EFI_PATH) -L$(LIB_PATH) -LCryptlib -LCryptlib/OpenSSL $(EFI_CRT_OBJS)
+LDFLAGS		= --hash-style=sysv -nostdlib -znocombreloc -T $(EFI_LDS) -shared -Bsymbolic -L$(EFI_PATH) -L$(LIB_PATH) -LCryptlib -LCryptlib/OpenSSL $(EFI_CRT_OBJS)
 
 VERSION		= 0.8
 


### PR DESCRIPTION
We depend on there being a .hash section in the binary, and that's not
the case on distributions that default to building with gnu-style ELF
hashes. Explicitly request sysv-style hashes in order to avoid building
broken binaries.

Signed-off-by: Matthew Garrett <mjg59@coreos.com>