### PR TITLE
Cryptlib: Define the va functions for EFIAPI

### DIFF
--- a/Cryptlib/Include/openssl/bio.h
+++ b/Cryptlib/Include/openssl/bio.h
@@ -787,11 +787,19 @@ void BIO_copy_next_retry(BIO *b);
 # else
 #  define __bio_h__attr__(x)
 # endif
+# if defined(OPENSSL_SYS_UEFI)
+int EFIAPI BIO_printf(BIO *bio, const char *format, ...)
+# else
 int BIO_printf(BIO *bio, const char *format, ...)
+# endif
 __bio_h__attr__((__format__(__printf__, 2, 3)));
 int BIO_vprintf(BIO *bio, const char *format, va_list args)
 __bio_h__attr__((__format__(__printf__, 2, 0)));
+# if defined(OPENSSL_SYS_UEFI)
+int EFIAPI BIO_snprintf(char *buf, size_t n, const char *format, ...)
+# else
 int BIO_snprintf(char *buf, size_t n, const char *format, ...)
+# endif
 __bio_h__attr__((__format__(__printf__, 3, 4)));
 int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
 __bio_h__attr__((__format__(__printf__, 3, 0)));

--- a/Cryptlib/Include/openssl/err.h
+++ b/Cryptlib/Include/openssl/err.h
@@ -352,11 +352,7 @@ void EFIAPI ERR_add_error_data(int num, ...);
 void ERR_add_error_data(int num, ...);
 #endif
 
-#if defined(OPENSSL_SYS_UEFI)
-void EFIAPI ERR_add_error_vdata(int num, va_list args);
-#else
 void ERR_add_error_vdata(int num, va_list args);
-#endif
 void ERR_load_strings(int lib, ERR_STRING_DATA str[]);
 void ERR_unload_strings(int lib, ERR_STRING_DATA str[]);
 void ERR_load_ERR_strings(void);

--- a/Cryptlib/Makefile
+++ b/Cryptlib/Makefile
@@ -7,7 +7,7 @@ CFLAGS		= -ggdb -O0 -I. -fno-stack-protector -fno-strict-aliasing -fpic -fshort-
 
 ifeq ($(ARCH),x86_64)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args \
-		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI
+		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -DNO_BUILTIN_VA_FUNCS
 endif
 ifeq ($(ARCH),ia32)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args -m32

--- a/Cryptlib/OpenSSL/Makefile
+++ b/Cryptlib/OpenSSL/Makefile
@@ -7,7 +7,8 @@ CFLAGS		= -ggdb -O0 -I. -I.. -I../Include/ -Icrypto -fno-stack-protector -fno-st
 
 ifeq ($(ARCH),x86_64)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -maccumulate-outgoing-args \
-		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -DSIXTY_FOUR_BIT_LONG
+		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -DSIXTY_FOUR_BIT_LONG \
+		-DNO_BUILTIN_VA_FUNCS
 endif
 ifeq ($(ARCH),ia32)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -maccumulate-outgoing-args \

--- a/Cryptlib/OpenSSL/crypto/bio/b_print.c
+++ b/Cryptlib/OpenSSL/crypto/bio/b_print.c
@@ -751,7 +751,11 @@ doapr_outch(char **sbuffer,
 
 /***************************************************************************/
 
+#if defined(OPENSSL_SYS_UEFI)
+int EFIAPI BIO_printf(BIO *bio, const char *format, ...)
+#else
 int BIO_printf(BIO *bio, const char *format, ...)
+#endif
 {
     va_list args;
     int ret;
@@ -795,7 +799,11 @@ int BIO_vprintf(BIO *bio, const char *format, va_list args)
  * closely related to BIO_printf, and we need *some* name prefix ... (XXX the
  * function should be renamed, but to what?)
  */
+#if defined(OPENSSL_SYS_UEFI)
+int EFIAPI BIO_snprintf(char *buf, size_t n, const char *format, ...)
+#else
 int BIO_snprintf(char *buf, size_t n, const char *format, ...)
+#endif
 {
     va_list args;
     int ret;

--- a/Cryptlib/OpenSSL/crypto/cryptlib.c
+++ b/Cryptlib/OpenSSL/crypto/cryptlib.c
@@ -962,7 +962,11 @@ void OPENSSL_showfatal(const char *fmta, ...)
         MessageBox(NULL, buf, _T("OpenSSL: FATAL"), MB_OK | MB_ICONSTOP);
 }
 #else
+# if defined(OPENSSL_SYS_UEFI)
+void EFIAPI OPENSSL_showfatal(const char *fmta, ...)
+# else
 void OPENSSL_showfatal(const char *fmta, ...)
+# endif
 {
     va_list ap;
 

--- a/Cryptlib/OpenSSL/crypto/cryptlib.h
+++ b/Cryptlib/OpenSSL/crypto/cryptlib.h
@@ -100,7 +100,11 @@ extern "C" {
 
 void OPENSSL_cpuid_setup(void);
 extern unsigned int OPENSSL_ia32cap_P[];
+# if defined(OPENSSL_SYS_UEFI)
+void EFIAPI OPENSSL_showfatal(const char *fmta, ...);
+# else
 void OPENSSL_showfatal(const char *fmta, ...);
+# endif
 void *OPENSSL_stderr(void);
 extern int OPENSSL_NONPIC_relocated;
 

--- a/Cryptlib/OpenSSL/crypto/err/err.c
+++ b/Cryptlib/OpenSSL/crypto/err/err.c
@@ -1085,11 +1085,7 @@ void ERR_add_error_data(int num, ...)
     va_end(args);
 }
 
-#if defined(OPENSSL_SYS_UEFI)
-void EFIAPI ERR_add_error_vdata(int num, va_list args)
-#else
 void ERR_add_error_vdata(int num, va_list args)
-#endif
 {
     int i, n, s;
     char *str, *p, *a;

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ ifeq ($(ARCH),x86_64)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc \
 		-maccumulate-outgoing-args \
 		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI \
+		-DNO_BUILTIN_VA_FUNCS \
 		"-DEFI_ARCH=L\"x64\"" \
 		"-DDEBUGDIR=L\"/usr/lib/debug/usr/share/shim/x64-$(VERSION)$(RELEASE)/\""
 endif


### PR DESCRIPTION
It turned out that my previous crash fix(*) was wrong.
We actually always used the gcc built-in va functions instead of
the "real" va functions for EFIAPI, and we are just lucky that
ERR_add_error_data didn't crash before.

This commit copies the va functions from MdePkg/Include/Base.h
in edk2 and introdues NO_BUILTIN_VA_FUNCS for x86_64, so that all
the x86_64 build will adopt the new va functions. For safety,
I also added EFIAPI to all the functions which use va_* to avoid
the potential trouble.

(*) a7f4b26cc35204165bd04e75c34e8e7aa2a87ecc

Signed-off-by: Gary Ching-Pang Lin <glin@suse.com>