### PR TITLE
Fix the size of MokDBState

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1920,7 +1920,7 @@ static EFI_STATUS check_mok_db (void)
 	EFI_GUID shim_lock_guid = SHIM_LOCK_GUID;
 	EFI_STATUS status = EFI_SUCCESS;
 	UINT8 MokDBState;
-	UINTN MokDBStateSize = sizeof(MokDBStateSize);
+	UINTN MokDBStateSize = sizeof(MokDBState);
 	UINT32 attributes;
 
 	status = uefi_call_wrapper(RT->GetVariable, 5, L"MokDBState", &shim_lock_guid,


### PR DESCRIPTION
MokDBState is a 8-bit unsigned integer. Looks like a typo here.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>