### PR TITLE
shim: remove unused variable

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1118,7 +1118,6 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	EFI_STATUS efi_status;
 	char *buffer;
 	int i;
-	unsigned int size;
 	EFI_IMAGE_SECTION_HEADER *Section;
 	char *base, *end;
 	PE_COFF_LOADER_IMAGE_CONTEXT context;


### PR DESCRIPTION
Fix the compilation error from gcc:

shim.c: In function ‘handle_image’:
shim.c:1121:15: error: unused variable ‘size’ [-Werror=unused-variable]
  unsigned int size;
               ^~~~

Signed-off-by: Gary Lin <glin@suse.com>