### PR TITLE
Don't close file twice in should_use_fallback error path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LD		= $(CROSS_COMPILE)ld
 OBJCOPY		= $(CROSS_COMPILE)objcopy
 
 ARCH		= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
-OBJCOPY_GTE224  = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.version //g' | cut -f1-2 -d.` \>= 2.24)
+OBJCOPY_GTE224  = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)
 
 SUBDIRS		= Cryptlib lib
 

--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,8 @@ endif
 		-j .note.gnu.build-id \
 		$(FORMAT) $^ $@.debug
 
-%.efi.signed: %.efi certdb/secmod.db
-	pesign -n certdb -i $< -c "shim" -s -o $@ -f
+%.efi.signed: %.efi shim.crt
+	sbsign --key shim.key --cert shim.crt $<
 
 clean:
 	$(MAKE) -C Cryptlib clean

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/
 EFI_CRT_OBJS 	= $(EFI_PATH)/crt0-efi-$(ARCH).o
 EFI_LDS		= elf_$(ARCH)_efi.lds
 
-DEFAULT_LOADER	:= \\\\grub.efi
+DEFAULT_LOADER	:= \\\\grubx64.efi
 CFLAGS		= -ggdb -O0 -fno-stack-protector -fno-strict-aliasing -fpic \
 		  -fshort-wchar -Wall -Wsign-compare -Werror -fno-builtin \
 		  -Werror=sign-compare -ffreestanding -std=gnu89 \

--- a/shim.c
+++ b/shim.c
@@ -1118,7 +1118,6 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	EFI_STATUS efi_status;
 	char *buffer;
 	int i;
-	unsigned int size;
 	EFI_IMAGE_SECTION_HEADER *Section;
 	char *base, *end;
 	PE_COFF_LOADER_IMAGE_CONTEXT context;

--- a/shim.c
+++ b/shim.c
@@ -1371,7 +1371,6 @@ should_use_fallback(EFI_HANDLE image_handle)
 		 * Print(L"Could not open \"\\EFI\\BOOT%s\": %d\n", FALLBACK,
 		 * 	 rc);
 		 */
-		uefi_call_wrapper(vh->Close, 1, vh);
 		goto error;
 	}
 


### PR DESCRIPTION
When fallback.efi is not present, the should_use_fallback error path attempts to close a file that has already been closed, resulting in hang. This issue only affects certain systems. 

This is a regression from version 0.8 and was introduced by commit 4794822.
The patch can be found in commit [9c0a4137](https://github.com/endlessm/shim/commit/9c0a41378ad3cfd7115530d0e8f4e94019ae24a9)

Signed-off-by: Benjamin Antin <ben.antin@endlessm.com>
