### PR TITLE
Don't close file twice in should_use_fallback error path

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1372,7 +1372,6 @@ should_use_fallback(EFI_HANDLE image_handle)
 		 * Print(L"Could not open \"\\EFI\\BOOT%s\": %d\n", FALLBACK,
 		 * 	 rc);
 		 */
-		uefi_call_wrapper(vh->Close, 1, vh);
 		goto error;
 	}
 


### PR DESCRIPTION
When fallback.efi is not present, the should_use_fallback error path
attempts to close a file that has already been closed, resulting in a
hang. This issue only affects certain systems.

This is a regression from version 0.8 and was introduced by commit
4794822.

Signed-off-by: Benjamin Antin <ben.antin@endlessm.com>