### PR TITLE
shim: trigger to record further logs to tcg 2.0 final event log area

### DIFF
--- a/tpm.h
+++ b/tpm.h
@@ -114,6 +114,8 @@ typedef struct tdEFI_TCG2_EVENT {
   uint8_t Event[1];
 } __attribute__ ((packed)) EFI_TCG2_EVENT;
 
+#define EFI_TCG2_EVENT_LOG_FORMAT_TCG_2 0x00000002
+
 struct efi_tpm2_protocol
 {
   EFI_STATUS (EFIAPI *get_capability) (struct efi_tpm2_protocol *this,


### PR DESCRIPTION
According to TCG EFI Protocol Specification for TPM 2.0 family,
all events generated after the invocation of EFI_TCG2_GET_EVENT_LOG
shall be stored in an instance of an EFI_CONFIGURATION_TABLE aka
EFI TCG 2.0 final events table. Hence, it is necessary to trigger the
internal switch through calling get_event_log() in order to allow
to retrieve the logs from OS runtime.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>