### PR TITLE
shim/tpm: fix trigger failure caused by NULL arguments 

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -71,9 +71,13 @@ static BOOLEAN tpm2_present(efi_tpm2_protocol_t *tpm)
  */
 static EFI_STATUS trigger_tcg2_final_events_table(efi_tpm2_protocol_t *tpm2)
 {
+	EFI_PHYSICAL_ADDRESS start;
+	EFI_PHYSICAL_ADDRESS end;
+	BOOLEAN truncated;
+
 	return uefi_call_wrapper(tpm2->get_event_log, 5, tpm2,
-				 EFI_TCG2_EVENT_LOG_FORMAT_TCG_2, NULL,
-				 NULL, NULL);
+				 EFI_TCG2_EVENT_LOG_FORMAT_TCG_2, &start,
+				 &end, &truncated);
 }
 
 EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,

--- a/tpm.c
+++ b/tpm.c
@@ -93,7 +93,7 @@ EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 
 		status = trigger_tcg2_final_events_table(tpm2);
 		if (EFI_ERROR(status)) {
-			perror(L"Unable to trigger tcg2 final events table\n");
+			perror(L"Unable to trigger tcg2 final events table: %r\n", status);
 			return status;
 		}
 


### PR DESCRIPTION
Certain BIOS may make the strict check on the last 3 arguments passed
to get_event_log() and don't expect NULL pointers are passed. In order
to work around this failure (EFI_INVALID_PARAMETER), pass them even
though we really don't use it.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>