### PR TITLE
shim/tpm: correct the definition of the capability structure for TCG 1.x

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -39,7 +39,7 @@ static BOOLEAN tpm2_present(efi_tpm2_protocol_t *tpm)
 {
 	EFI_STATUS status;
 	EFI_TCG2_BOOT_SERVICE_CAPABILITY caps;
-	EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 *caps_1_0;
+	EFI_TCG_BOOT_SERVICE_CAPABILITY *caps_1_0;
 
 	caps.Size = (UINT8)sizeof(caps);
 
@@ -50,7 +50,7 @@ static BOOLEAN tpm2_present(efi_tpm2_protocol_t *tpm)
 
 	if (caps.StructureVersion.Major == 1 &&
 	    caps.StructureVersion.Minor == 0) {
-		caps_1_0 = (EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 *)&caps;
+		caps_1_0 = (EFI_TCG_BOOT_SERVICE_CAPABILITY *)&caps;
 		if (caps_1_0->TPMPresentFlag)
 			return TRUE;
 	} else {

--- a/tpm.h
+++ b/tpm.h
@@ -65,24 +65,26 @@ typedef uint32_t EFI_TCG2_EVENT_LOG_BITMAP;
 typedef uint32_t EFI_TCG2_EVENT_LOG_FORMAT;
 typedef uint32_t EFI_TCG2_EVENT_ALGORITHM_BITMAP;
 
+typedef struct tdEFI_TCG_VERSION {
+  uint8_t Major;
+  uint8_t Minor;
+  uint8_t RevMajor;
+  uint8_t RevMinor;
+} __attribute__ ((packed)) EFI_TCG_VERSION;
+
 typedef struct tdEFI_TCG2_VERSION {
   uint8_t Major;
   uint8_t Minor;
 } __attribute__ ((packed)) EFI_TCG2_VERSION;
 
-typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 {
+typedef struct tdEFI_TCG_BOOT_SERVICE_CAPABILITY {
   uint8_t Size;
-  EFI_TCG2_VERSION StructureVersion;
-  EFI_TCG2_VERSION ProtocolVersion;
-  EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
-  EFI_TCG2_EVENT_LOG_BITMAP SupportedEventLogs;
+  EFI_TCG_VERSION StructureVersion;
+  EFI_TCG_VERSION ProtocolVersion;
+  uint8_t HashAlgorithmBitmap;
   BOOLEAN TPMPresentFlag;
-  uint16_t MaxCommandSize;
-  uint16_t MaxResponseSize;
-  uint32_t ManufacturerID;
-  uint32_t NumberOfPcrBanks;
-  EFI_TCG2_EVENT_ALGORITHM_BITMAP ActivePcrBanks;
-} EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0;
+  BOOLEAN TPMDeactivatedFlag;
+} EFI_TCG_BOOT_SERVICE_CAPABILITY;
 
 typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY {
   uint8_t Size;


### PR DESCRIPTION
Page 13-14 in "TCG EFI Protocol Specification For TPM Family 1.1 or 1.2
Specification Version 1.22 Revision 5" gives the right definition of
the capability structure for TCG 1.x.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>