### PR TITLE
shim/tpm: correct the definition of the capability structure version 1.0

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -39,7 +39,7 @@ static BOOLEAN tpm2_present(efi_tpm2_protocol_t *tpm)
 {
 	EFI_STATUS status;
 	EFI_TCG2_BOOT_SERVICE_CAPABILITY caps;
-	EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 *caps_1_0;
+	TREE_BOOT_SERVICE_CAPABILITY *caps_1_0;
 
 	caps.Size = (UINT8)sizeof(caps);
 
@@ -50,8 +50,8 @@ static BOOLEAN tpm2_present(efi_tpm2_protocol_t *tpm)
 
 	if (caps.StructureVersion.Major == 1 &&
 	    caps.StructureVersion.Minor == 0) {
-		caps_1_0 = (EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 *)&caps;
-		if (caps_1_0->TPMPresentFlag)
+		caps_1_0 = (TREE_BOOT_SERVICE_CAPABILITY *)&caps;
+		if (caps_1_0->TrEEPresentFlag)
 			return TRUE;
 	} else {
 		if (caps.TPMPresentFlag)

--- a/tpm.h
+++ b/tpm.h
@@ -61,28 +61,33 @@ struct efi_tpm_protocol
 
 typedef struct efi_tpm_protocol efi_tpm_protocol_t;
 
+typedef uint32_t TREE_EVENT_LOG_BITMAP;
+
 typedef uint32_t EFI_TCG2_EVENT_LOG_BITMAP;
 typedef uint32_t EFI_TCG2_EVENT_LOG_FORMAT;
 typedef uint32_t EFI_TCG2_EVENT_ALGORITHM_BITMAP;
+
+typedef struct tdTREE_VERSION {
+  uint8_t Major;
+  uint8_t Minor;
+} TREE_VERSION;
 
 typedef struct tdEFI_TCG2_VERSION {
   uint8_t Major;
   uint8_t Minor;
 } __attribute__ ((packed)) EFI_TCG2_VERSION;
 
-typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0 {
+typedef struct tdTREE_BOOT_SERVICE_CAPABILITY {
   uint8_t Size;
-  EFI_TCG2_VERSION StructureVersion;
-  EFI_TCG2_VERSION ProtocolVersion;
-  EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
-  EFI_TCG2_EVENT_LOG_BITMAP SupportedEventLogs;
-  BOOLEAN TPMPresentFlag;
+  TREE_VERSION StructureVersion;
+  TREE_VERSION ProtocolVersion;
+  uint32_t HashAlgorithmBitmap;
+  TREE_EVENT_LOG_BITMAP SupportedEventLogs;
+  BOOLEAN TrEEPresentFlag;
   uint16_t MaxCommandSize;
   uint16_t MaxResponseSize;
   uint32_t ManufacturerID;
-  uint32_t NumberOfPcrBanks;
-  EFI_TCG2_EVENT_ALGORITHM_BITMAP ActivePcrBanks;
-} EFI_TCG2_BOOT_SERVICE_CAPABILITY_1_0;
+} TREE_BOOT_SERVICE_CAPABILITY;
 
 typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY {
   uint8_t Size;

--- a/tpm.h
+++ b/tpm.h
@@ -75,7 +75,7 @@ typedef struct tdTREE_VERSION {
 typedef struct tdEFI_TCG2_VERSION {
   uint8_t Major;
   uint8_t Minor;
-} __attribute__ ((packed)) EFI_TCG2_VERSION;
+} EFI_TCG2_VERSION;
 
 typedef struct tdTREE_BOOT_SERVICE_CAPABILITY {
   uint8_t Size;
@@ -101,7 +101,7 @@ typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY {
   uint32_t ManufacturerID;
   uint32_t NumberOfPcrBanks;
   EFI_TCG2_EVENT_ALGORITHM_BITMAP ActivePcrBanks;
-} __attribute__ ((packed))  EFI_TCG2_BOOT_SERVICE_CAPABILITY;
+} EFI_TCG2_BOOT_SERVICE_CAPABILITY;
 
 typedef uint32_t TCG_PCRINDEX;
 typedef uint32_t TCG_EVENTTYPE;


### PR DESCRIPTION
EFI TrEE Protocol uses the same protocol GUID as EFI TCG2 protocol, and
defines the capability structure version 1.0. Hence, the structure and
name are all align the EFI TrEE Protocol.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>