### PR TITLE
generate_hash(): fix the regression

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -891,7 +891,7 @@ static EFI_STATUS generate_hash (char *data, unsigned int datasize_in,
 		hashsize = datasize - context->SecDir->Size - SumOfBytesHashed;
 
 		if ((datasize - SumOfBytesHashed < context->SecDir->Size) ||
-		    (SumOfBytesHashed - hashsize != context->SecDir->VirtualAddress)) {
+		    (SumOfBytesHashed + hashsize != context->SecDir->VirtualAddress)) {
 			perror(L"Malformed binary after Attribute Certificate Table\n");
 			status = EFI_INVALID_PARAMETER;
 			goto done;


### PR DESCRIPTION
The commit 03b9f800 introduces an issue in case the gap between
SumOfBytesHashed and context->SecDir->VirtualAddress exists.

This would be a typo because a formal PE image always meet
SumOfBytesHashed + hashsize == context->SecDir->VirtualAddress either
the gap exists or not.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>